### PR TITLE
Fix decoding when alphabet contains regex-like special chars

### DIFF
--- a/src/main/java/org/sqids/Sqids.java
+++ b/src/main/java/org/sqids/Sqids.java
@@ -124,22 +124,23 @@ public class Sqids {
                 .append(this.alphabet, 0, offset)
                 .reverse()
                 .toString();
-        String slicedId = id.substring(1);
 
-        while (!slicedId.isEmpty()) {
+        int index = 1;
+        while (true) {
             final char separator = alphabet.charAt(0);
-            final String[] chunks = slicedId.split(String.valueOf(separator), 2);
-            final int chunksLength = chunks.length;
-            if (chunksLength > 0) {
-                if (chunks[0].isEmpty()) {
-                    return ret;
-                }
-                ret.add(toNumber(chunks[0], alphabet.substring(1)));
-                if (chunksLength > 1) {
-                    alphabet = shuffle(alphabet);
-                }
+            int seperatorIndex = id.indexOf(separator, index);
+            if (seperatorIndex == -1) {
+                seperatorIndex = id.length();
+            } else if (index == seperatorIndex) {
+                break;
             }
-            slicedId = chunksLength > 1 ? chunks[1] : "";
+            ret.add(toNumber(id, index, seperatorIndex, alphabet.substring(1)));
+            index = seperatorIndex + 1;
+            if (index < id.length()) {
+                alphabet = shuffle(alphabet);
+            } else {
+                break;
+            }
         }
         return ret;
     }
@@ -217,15 +218,13 @@ public class Sqids {
         return id.reverse();
     }
 
-    private long toNumber(final String id, final String alphabet) {
-        char[] chars = alphabet.toCharArray();
-        int charLength = chars.length;
+    private long toNumber(final String id, final int fromInclusive, final int toExclusive, final String alphabet) {
+        int alphabetLength = alphabet.length();
         long number = 0;
-
-        for (char c : id.toCharArray()) {
-            number = number * charLength + alphabet.indexOf(c);
+        for (int i = fromInclusive; i < toExclusive; i++) {
+            char c = id.charAt(i);
+            number = number * alphabetLength + alphabet.indexOf(c);
         }
-
         return number;
     }
 

--- a/src/main/java/org/sqids/Sqids.java
+++ b/src/main/java/org/sqids/Sqids.java
@@ -128,14 +128,14 @@ public class Sqids {
         int index = 1;
         while (true) {
             final char separator = alphabet.charAt(0);
-            int seperatorIndex = id.indexOf(separator, index);
-            if (seperatorIndex == -1) {
-                seperatorIndex = id.length();
-            } else if (index == seperatorIndex) {
+            int separatorIndex = id.indexOf(separator, index);
+            if (separatorIndex == -1) {
+                separatorIndex = id.length();
+            } else if (index == separatorIndex) {
                 break;
             }
-            ret.add(toNumber(id, index, seperatorIndex, alphabet.substring(1)));
-            index = seperatorIndex + 1;
+            ret.add(toNumber(id, index, separatorIndex, alphabet.substring(1)));
+            index = separatorIndex + 1;
             if (index < id.length()) {
                 alphabet = shuffle(alphabet);
             } else {

--- a/src/test/java/org/sqids/AlphabetTests.java
+++ b/src/test/java/org/sqids/AlphabetTests.java
@@ -28,6 +28,15 @@ public class AlphabetTests {
     }
 
     @Test
+    public void specialCharsAlphabet() {
+        Sqids sqids = Sqids.builder()
+                .alphabet(".\\?")
+                .build();
+        List<Long> numbers = Arrays.asList(1L, 2L, 3L);
+        Assertions.assertEquals(sqids.decode(sqids.encode(numbers)), numbers);
+    }
+
+    @Test
     public void multibyteCharacters() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> Sqids.builder()
                 .alphabet("ë1092")


### PR DESCRIPTION
The `decode` method uses [String.split](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#split-java.lang.String-int-) to find the chunks it needs to work on. This breaks if the alphabet has RegEx special characters in it.

e.g.

```java
        Sqids sqids = Sqids.builder()
                .alphabet(".\\?")
                .build();
        List<Long> numbers = Arrays.asList(1L, 2L, 3L);
        sqids.decode(sqids.encode(numbers)), numbers);
 ```

A simple fix would be to wrap the pattern with [Pattern.quote](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#quote-java.lang.String-), but I took it as an opportunity to optimize the decode a bit to reduce the number of objects we need to create.